### PR TITLE
Attendee Event Registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,4 +98,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "rails-controller-testing"
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,30 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-  protect_from_forgery with: :exception 
+  protect_from_forgery with: :exception
+
+  before_action :sign_out_on_public_pages
+
+  def after_sign_in_path_for(_resource)
+    attendee_dashboard_index_path
+  end
+
+  def after_sign_up_path_for(_resource)
+    attendee_dashboard_index_path
+  end
+
+  def after_sign_out_path_for(_resource_or_scope)
+    root_path
+  end
+
+  private
+
+  def sign_out_on_public_pages
+    public_pages = [ about_path, root_path ]
+
+    return unless user_signed_in? && public_pages.include?(request.path)
+
+    sign_out(current_user)
+    redirect_to root_path, alert: "You have been signed out."
+  end
 end

--- a/app/controllers/attendee_dashboard_controller.rb
+++ b/app/controllers/attendee_dashboard_controller.rb
@@ -1,0 +1,10 @@
+class AttendeeDashboardController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+  end
+
+  def events
+    @events = RecommendedEventsService.new(current_user).call
+  end
+end

--- a/app/controllers/event_registration_controller.rb
+++ b/app/controllers/event_registration_controller.rb
@@ -1,6 +1,12 @@
 class EventRegistrationController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_event_registration, only: [:destroy, :show]
+  before_action :authorize_attendee!, only: [:destroy, :register]
+  before_action :check_owner!, only: [:destroy, :show]
+
   def destroy
     @event_registration = EventRegistration.find(params[:id])
+
     if @event_registration.destroy
       redirect_to events_path, notice: "Event registration was successfully canceled."
     else
@@ -12,12 +18,7 @@ class EventRegistrationController < ApplicationController
     @event = Event.find(params[:id])
     @user = current_user
 
-    unless @user.is_a?(AttendeeUser)
-      redirect_to events_path, alert: "Only attendees can register for events." and return
-    end
-
-    # if user is already registered for this event, return
-    if @user.event_registrations.where(event_id: @event.id).count > 0
+    if @user.registered_for_event?(@event.id)
       redirect_to events_path, alert: "You are already registered for this event." and return
     end
 
@@ -40,5 +41,24 @@ class EventRegistrationController < ApplicationController
 
   def event_registration_params
     params.require(:event_registration).permit(:event_id, :attendee_id)
+  end
+
+  def authorize_attendee!
+    unless current_user.is_a?(AttendeeUser)
+      redirect_to events_path, alert: "Only attendees can perform this action." and return
+    end
+  end
+
+  def check_owner!
+    unless @event_registration.attendee_id == current_user.id
+      redirect_to events_path, notice: "Only the owner of this event registration can perform this action."
+    end
+  end
+
+  def set_event_registration
+    @event_registration = EventRegistration.find_by(id: params[:id])
+    unless @event_registration
+      redirect_to events_path, alert: "Event registration not found."
+    end
   end
 end

--- a/app/controllers/event_registration_controller.rb
+++ b/app/controllers/event_registration_controller.rb
@@ -1,0 +1,44 @@
+class EventRegistrationController < ApplicationController
+  def destroy
+    @event_registration = EventRegistration.find(params[:id])
+    if @event_registration.destroy
+      redirect_to events_path, notice: "Event registration was successfully canceled."
+    else
+      redirect_to events_path, alert: "Error: Unable to cancel event registration."
+    end
+  end
+
+  def register
+    @event = Event.find(params[:id])
+    @user = current_user
+
+    unless @user.is_a?(AttendeeUser)
+      redirect_to events_path, alert: "Only attendees can register for events." and return
+    end
+
+    # if user is already registered for this event, return
+    if @user.event_registrations.where(event_id: @event.id).count > 0
+      redirect_to events_path, alert: "You are already registered for this event." and return
+    end
+
+    @event_registration = EventRegistration.new(attendee_id: @user.id, event_id: @event.id)
+
+    if @event_registration.save
+      redirect_to @event_registration, notice: "You successfully registered for #{@event.name}."
+    else
+      redirect_to @event, alert: "Registration failed: #{@event_registration.errors.full_messages.to_sentence}"
+    end
+  end
+
+  def show
+    @event_registration = EventRegistration.find(params[:id])
+    @event = @event_registration.event
+    @user = @event_registration.attendee
+  end
+
+  private
+
+  def event_registration_params
+    params.require(:event_registration).permit(:event_id, :attendee_id)
+  end
+end

--- a/app/controllers/event_registration_controller.rb
+++ b/app/controllers/event_registration_controller.rb
@@ -29,6 +29,7 @@ class EventRegistrationController < ApplicationController
     @event_registration = EventRegistration.new(attendee_id:, event_id:, role:)
 
     if @event_registration.save
+      EventRegistrationMailer.registration_confirmation(@event_registration).deliver_later
       redirect_to @event_registration, notice: "You successfully registered for #{@event_registration.event.name}."
     else
       redirect_to @event, alert: "Registration failed: #{@event_registration.errors.full_messages.to_sentence}"

--- a/app/mailers/event_registration_mailer.rb
+++ b/app/mailers/event_registration_mailer.rb
@@ -1,0 +1,13 @@
+class EventRegistrationMailer < ApplicationMailer
+    def registration_confirmation(event_registration)
+      @event_registration = event_registration
+      @event = @event_registration.event
+      @attendee = @event_registration.attendee
+  
+      mail(
+        to: @attendee.email,
+        subject: "Registration Confirmation for #{@event.name}"
+      )
+    end
+  end
+  

--- a/app/models/attendee_user.rb
+++ b/app/models/attendee_user.rb
@@ -2,4 +2,12 @@ class AttendeeUser < User
   has_many :event_registrations, foreign_key: :attendee_id
 
   validates :attendee_type, presence: true, inclusion: { in: %(speaker listener) }
+
+  def get_registration_for_event(event_id)
+    event_registrations.find_by(event_id: event_id)&.id
+  end
+
+  def registered_for_event?(event_id)
+    EventRegistration.exists?(attendee_id: self.id, event_id:)
+  end
 end

--- a/app/models/attendee_user.rb
+++ b/app/models/attendee_user.rb
@@ -1,5 +1,6 @@
 class AttendeeUser < User
   has_many :event_registrations, foreign_key: :attendee_id
+  has_many :events, through: :event_registrations
 
   validates :attendee_type, presence: true, inclusion: { in: %(speaker listener) }
 

--- a/app/models/attendee_user.rb
+++ b/app/models/attendee_user.rb
@@ -1,3 +1,5 @@
 class AttendeeUser < User
+  has_many :event_registrations, foreign_key: :attendee_id
+
   validates :attendee_type, presence: true, inclusion: { in: %(speaker listener) }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,9 +1,11 @@
 class Event < ApplicationRecord
+    has_many :event_registrations
+    has_many :attendees, through: :event_registrations, source: :attendee
+
     belongs_to :organizer, class_name: "User", foreign_key: "organizer_id"
-  
+    belongs_to :venue, optional: true
+
     validates :name, presence: true
     validates :event_type, presence: true, inclusion: { in: %w[conference workshop seminar competition other] }
-    validates :location, presence: true
     validates :organizer_id, presence: true
-  end
-  
+end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,4 +1,4 @@
 class EventRegistration < ApplicationRecord
   belongs_to :event
-  belongs_to :attendee, class_name: 'User'
+  belongs_to :attendee, class_name: 'AttendeeUser'
 end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,0 +1,4 @@
+class EventRegistration < ApplicationRecord
+  belongs_to :event
+  belongs_to :attendee, class_name: 'User'
+end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,4 +1,18 @@
 class EventRegistration < ApplicationRecord
   belongs_to :event
   belongs_to :attendee, class_name: 'AttendeeUser'
+
+  validates :role, presence: :true
+  validates :role, inclusion: { in: %[listener speaker] }
+  validate :only_speaker_attendee_can_register_as_speaker
+
+  private
+
+  def only_speaker_attendee_can_register_as_speaker
+    if role == "speaker"
+      unless AttendeeUser.exists?(id: attendee_id, attendee_type: "speaker")
+        errors.add(:attendee_id, "must correspond to a valid speaker attendee")
+      end
+    end
+  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,10 +2,6 @@ class Organization < ApplicationRecord
     validates :name, presence: true
     validates :website, format: { with: /\Ahttps?:\/\/[\S]+\z/, message: "must be a valid URL" }, allow_blank: true
     validates :phone, format: { with: /\A\+?[0-9]{10,15}\z/, message: "must be a valid phone number" }, allow_blank: true
-    validates :locations, presence: { message: "must have at least one location" }
-    
-    has_many :users
-    has_many :locations, dependent: :destroy
 
-    accepts_nested_attributes_for :locations
+    has_many :users
 end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,0 +1,7 @@
+class Venue < ApplicationRecord
+  has_many :events
+
+  validates :name, :max_capacity, :price_per_seat, :location_id, presence: :true
+  validates :price_per_seat, comparison: { greater_than_or_equal_to: 0.0 }
+  validates :max_capacity, comparison: { greater_than: 0 }
+end

--- a/app/services/recommended_events_service.rb
+++ b/app/services/recommended_events_service.rb
@@ -1,0 +1,17 @@
+class RecommendedEventsService
+  def initialize(user, strategy: nil)
+    @user = user
+    @strategy = strategy || determine_strategy
+  end
+
+  def call
+    @strategy.recommend(@user)
+  end
+
+  private
+
+  def determine_strategy
+    # Default strategy for now since we don't have user preferences yet
+    EventTypeBasedRecommendationStrategy.new
+  end
+end

--- a/app/strategies/event_category_based_recommendation_strategy.rb
+++ b/app/strategies/event_category_based_recommendation_strategy.rb
@@ -1,0 +1,9 @@
+class EventCategoryBasedRecommendationStrategy
+  include RecommendationStrategy
+
+  def recommend(user)
+    # TODO: uncomment this once category is added to event model
+    # preferred_categories = user.events.pluck(:category).uniq
+    # Event.where(category: preferred_categories).order(created_at: :desc).limit(10)
+  end
+end

--- a/app/strategies/event_recommendation_strategy.rb
+++ b/app/strategies/event_recommendation_strategy.rb
@@ -1,0 +1,5 @@
+module EventRecommendationStrategy
+  def recommend(user)
+    raise NotImplementedError, "Recommendation strategy must implement the recommend method"
+  end
+end

--- a/app/strategies/event_type_based_recommendation_strategy.rb
+++ b/app/strategies/event_type_based_recommendation_strategy.rb
@@ -1,0 +1,15 @@
+class EventTypeBasedRecommendationStrategy
+  include EventRecommendationStrategy
+
+  def recommend(attendee_user)
+    preferred_event_types = attendee_user.events.distinct.pluck(:event_type)
+
+    if preferred_event_types.empty?
+      events = Event.order(created_at: :desc)
+    else
+      events = Event.where(event_type: preferred_event_types).order(created_at: :desc)
+    end
+
+    events.reject { |event| attendee_user.registered_for_event?(event.id) }.first(10)
+  end
+end

--- a/app/views/attendee_dashboard/events.html.erb
+++ b/app/views/attendee_dashboard/events.html.erb
@@ -1,0 +1,24 @@
+<div class="container mt-4">
+  <h1>Events</h1>
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <div class="list-group">
+        <% @events.each do |event| %>
+        <div class="list-group-item d-flex justify-content-between align-items-center mb-3">
+          <div>
+            <h5 class="mb-1"><%= event.name %></h5>
+            <p class="mb-1"><%= event.description %></p>
+            <small class="text-muted">Event Type: <%= event.event_type %></small>
+          </div>
+          <div>
+            <%= link_to "Register as listener", register_as_listener_event_path(event), class: 'btn btn-primary btn-sm', method: :post, data: { turbo_method: :post } %>
+            <% if current_user.attendee_type == "speaker" %>
+            <%= link_to "Register as speaker", register_as_speaker_event_path(event), class: 'btn btn-secondary btn-sm', method: :post, data: { turbo_method: :post } %>
+            <% end %>
+          </div>
+        </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/attendee_dashboard/index.html.erb
+++ b/app/views/attendee_dashboard/index.html.erb
@@ -1,0 +1,3 @@
+<h1>AttendeeDashboard#index</h1>
+<p>Find me in app/views/attendee_dashboard/index.html.erb</p>
+<%= link_to "Events", attendee_dashboard_events_path %>

--- a/app/views/event_registration/register.html.erb
+++ b/app/views/event_registration/register.html.erb
@@ -1,0 +1,2 @@
+<h1>EventRegistration#register</h1>
+<p>Find me in app/views/event_registration/register.html.erb</p>

--- a/app/views/event_registration/show.html.erb
+++ b/app/views/event_registration/show.html.erb
@@ -4,6 +4,6 @@
 <p><strong>Attendee:</strong> <%= @user.first_name + " " + @user.last_name %></p>
 <p><strong>Role:</strong> <%= @event_registration.role %></p>
 
-<%= link_to "Back to Events", events_path, class: "btn btn-secondary" %>
+<%= link_to "Back to Events", attendee_dashboard_events_path, class: "btn btn-secondary" %>
 
 <%= link_to "Cancel your attendance for this event", event_registration_path(@event_registration), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-danger" %>

--- a/app/views/event_registration/show.html.erb
+++ b/app/views/event_registration/show.html.erb
@@ -1,0 +1,9 @@
+<h1>Event Registration</h1>
+
+<p><strong>Event:</strong> <%= @event_registration.event.name.capitalize %></p>
+<p><strong>Attendee:</strong> <%= @user.first_name + " " + @user.last_name %></p>
+<p><strong>Role:</strong> <%= @user.attendee_type %></p>
+
+<%= link_to "Back to Events", events_path, class: "btn btn-secondary" %>
+
+<%= link_to "Cancel your attendance for this event", event_registration_path(@event_registration), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-danger" %>

--- a/app/views/event_registration/show.html.erb
+++ b/app/views/event_registration/show.html.erb
@@ -2,7 +2,7 @@
 
 <p><strong>Event:</strong> <%= @event_registration.event.name.capitalize %></p>
 <p><strong>Attendee:</strong> <%= @user.first_name + " " + @user.last_name %></p>
-<p><strong>Role:</strong> <%= @user.attendee_type %></p>
+<p><strong>Role:</strong> <%= @event_registration.role %></p>
 
 <%= link_to "Back to Events", events_path, class: "btn btn-secondary" %>
 

--- a/app/views/event_registration_mailer/registration_confirmation.html.erb
+++ b/app/views/event_registration_mailer/registration_confirmation.html.erb
@@ -1,0 +1,14 @@
+<h1>Registration Confirmation</h1>
+
+<p>Hello <%= @attendee.first_name %>,</p>
+
+<p>You have successfully registered for the event: <strong><%= @event.name %></strong>.</p>
+
+<p>Event Details:</p>
+<ul>
+  <li>Event: <%= @event.name %></li>
+  <li>Location: <%= @event.location %></li>
+  <li>Role: <%= @event_registration.role.capitalize %></li>
+</ul>
+
+<p>Thank you for registering!</p>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,17 +1,16 @@
 <h1>All Events</h1>
 
 <% @events.each do |event| %>
-  <div class="event-card">
-    <h3><%= link_to event.name, event_path(event) %></h3>
-    <p><strong>Type:</strong> <%= event.event_type.capitalize %></p>
-    <p><strong>Location:</strong> <%= event.location %></p>
-    <p><strong>Organizer:</strong> <%= event.organizer.username %></p>
+<div class="event-card">
+  <h3><%= link_to event.name, event_path(event) %></h3>
+  <p><strong>Type:</strong> <%= event.event_type.capitalize %></p>
+  <p><strong>Organizer:</strong> <%= event.organizer.username %></p>
 
-    <% if current_user.is_a?(OrganizerUser) || current_user.is_a?(ExecutiveUser) || current_user.is_a?(AdminUser) %>
-      <%= link_to "Edit", edit_event_path(event), class: "btn btn-primary" %>
-      <%= link_to "Delete", event_path(event), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
-    <% end %>
-  </div>
+  <% if current_user.is_a?(OrganizerUser) || current_user.is_a?(ExecutiveUser) || current_user.is_a?(AdminUser) %>
+  <%= link_to "Edit", edit_event_path(event), class: "btn btn-primary" %>
+  <%= link_to "Delete", event_path(event), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
+  <% end %>
+</div>
 <% end %>
 
 <%= link_to "Create New Event", new_event_path, class: "btn btn-success" if current_user.is_a?(OrganizerUser) || current_user.is_a?(ExecutiveUser) || current_user.is_a?(AdminUser)%>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,7 +10,10 @@
   <% if current_user.registered_for_event?(@event.id) %>
     <%= link_to "View registration details", event_registration_path(current_user.get_registration_for_event(@event.id)), class: "btn btn-success" %>
   <% else %>
-    <%= link_to "Register", register_event_path(@event), method: :post, class: "btn btn-success" %>
+    <%= link_to "Register as listener", register_as_listener_event_path(@event), method: :post, class: "btn btn-success" %>
+    <% if current_user.attendee_type == "speaker" %>
+      <%= link_to "Register as speaker", register_as_speaker_event_path(@event), method: :post, class: "btn btn-success" %>
+    <% end %>
   <% end %>
 <% end %>
 <% if current_user.is_a?(OrganizerUser) || current_user.is_a?(ExecutiveUser) || current_user.is_a?(AdminUser) %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,7 +7,11 @@
 <%= link_to "Back to Events", events_path, class: "btn btn-secondary" %>
 
 <% if current_user.is_a?(AttendeeUser) %>
-  <%= link_to "Register", register_event_path(@event), method: :post, class: "btn btn-success" %>
+  <% if current_user.registered_for_event?(@event.id) %>
+    <%= link_to "View registration details", event_registration_path(current_user.get_registration_for_event(@event.id)), class: "btn btn-success" %>
+  <% else %>
+    <%= link_to "Register", register_event_path(@event), method: :post, class: "btn btn-success" %>
+  <% end %>
 <% end %>
 <% if current_user.is_a?(OrganizerUser) || current_user.is_a?(ExecutiveUser) || current_user.is_a?(AdminUser) %>
   <%= link_to "Edit Event", edit_event_path(@event), class: "btn btn-primary" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,6 +6,9 @@
 
 <%= link_to "Back to Events", events_path, class: "btn btn-secondary" %>
 
+<% if current_user.is_a?(AttendeeUser) %>
+  <%= link_to "Register", register_event_path(@event), method: :post, class: "btn btn-success" %>
+<% end %>
 <% if current_user.is_a?(OrganizerUser) || current_user.is_a?(ExecutiveUser) || current_user.is_a?(AdminUser) %>
   <%= link_to "Edit Event", edit_event_path(@event), class: "btn btn-primary" %>
   <%= link_to "Delete", event_path(@event), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-danger" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,41 +1,41 @@
 <div class="container col-xxl-8 px-4 py-5">
-    <div class="row flex-lg-row-reverse align-items-center g-5 py-5">
-        <div class="col-10 col-sm-8 col-lg-6">
-            <%= image_tag("edu-events-home.png", height: "400px", class: "d-block mx-lg-auto img-fluid", loading: "lazy") %>
-        </div>
-        <div class="col-lg-6">
-            <h1 class="display-5 fw-bold lh-1 mb-3">Finally, a smart educational events system.</h1>
-            <p class="lead">Providing a smart centralized platform to manage and attend educational events.</p>
-            <div class="d-grid gap-2 d-md-flex justify-content-md-start">
-                <%= link_to "Learn More", about_path, class: "btn btn-primary btn-lg px-4 me-md-2"%>
-            </div>
-        </div>
+  <div class="row flex-lg-row-reverse align-items-center g-5 py-5">
+    <div class="col-10 col-sm-8 col-lg-6">
+      <%= image_tag("edu-events-home.png", height: "400px", class: "d-block mx-lg-auto img-fluid", loading: "lazy") %>
     </div>
+    <div class="col-lg-6">
+      <h1 class="display-5 fw-bold lh-1 mb-3">Finally, a smart educational events system.</h1>
+      <p class="lead">Providing a smart centralized platform to manage and attend educational events.</p>
+      <div class="d-grid gap-2 d-md-flex justify-content-md-start">
+        <%= link_to "Learn More", about_path, class: "btn btn-primary btn-lg px-4 me-md-2"%>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="bg-orange text-secondary px-4 py-5 text-center">
-    <div class="py-5">
-        <h1 class="display-5 fw-bold text-white">Why choose us?</h1>
-        <div class="col-lg-6 mx-auto">
-            <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-                <div class="cards">
-                    <div class="card">
-                        <i class="fa-solid fa-globe fa-3x"></i>
-                        <h2>Seamless Networking</h2>
-                        <p>Foster meaningful connections with direct messaging, interactive Q&A sections, and dedicated discussion forums to keep conversations going before, during, and after events.</p>
-                    </div>
-                    <div class="card">
-                        <i class="fa-solid fa-bolt fa-3x"></i>
-                        <h2>Automated Event Management</h2>
-                        <p>Streamline event planning with real-time venue scheduling, automatic confirmations for organizers and speakers, and a hassle-free booking experience.</p>
-                    </div>
-                    <div class="card">
-                        <i class="fa-solid fa-chart-simple fa-3x"></i>
-                        <h2>Advanced Analytics</h2>
-                        <p>Gain valuable insights with attendee feedback and attendance tracking, helping speakers and organizers improve future events while rewarding participants with exclusive perks.</p>
-                    </div>
-                </div>
-            </div>
+  <div class="py-5">
+    <h1 class="display-5 fw-bold text-white">Why choose us?</h1>
+    <div class="col-lg-6 mx-auto">
+      <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
+        <div class="cards">
+          <div class="card">
+            <i class="fa-solid fa-globe fa-3x"></i>
+            <h2>Seamless Networking</h2>
+            <p>Foster meaningful connections with direct messaging, interactive Q&A sections, and dedicated discussion forums to keep conversations going before, during, and after events.</p>
+          </div>
+          <div class="card">
+            <i class="fa-solid fa-bolt fa-3x"></i>
+            <h2>Automated Event Management</h2>
+            <p>Streamline event planning with real-time venue scheduling, automatic confirmations for organizers and speakers, and a hassle-free booking experience.</p>
+          </div>
+          <div class="card">
+            <i class="fa-solid fa-chart-simple fa-3x"></i>
+            <h2>Advanced Analytics</h2>
+            <p>Gain valuable insights with attendee feedback and attendance tracking, helping speakers and organizers improve future events while rewarding participants with exclusive perks.</p>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,7 @@ Rails.application.configure do
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener_web
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   get "about" => "home#about"
   root "home#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,11 @@ Rails.application.routes.draw do
 
   get "about" => "home#about"
   root "home#index"
-  resources :events
+
+  resources :event_registration
+  resources :events do
+    member do
+      post :register, to: "event_registration#register"
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,8 @@ Rails.application.routes.draw do
   resources :event_registration
   resources :events do
     member do
-      post :register, to: "event_registration#register"
+      post :register_as_listener, to: "event_registration#register_as_listener"
+      post :register_as_speaker, to: "event_registration#register_as_speaker"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   get "about" => "home#about"
   root "home#index"
 
+  get "attendee_dashboard/index", to: "attendee_dashboard#index", as: "attendee_dashboard_index"
+  get "attendee_dashboard/events", to: "attendee_dashboard#events", as: "attendee_dashboard_events"
+
   resources :event_registration
   resources :events do
     member do

--- a/db/migrate/20250321185904_create_event_registrations.rb
+++ b/db/migrate/20250321185904_create_event_registrations.rb
@@ -3,6 +3,7 @@ class CreateEventRegistrations < ActiveRecord::Migration[8.0]
     create_table :event_registrations do |t|
       t.references :event, null: false, foreign_key: true
       t.references :attendee, null: false, foreign_key: { to_table: :users }
+      t.string :role
 
       t.timestamps
     end

--- a/db/migrate/20250321185904_create_event_registrations.rb
+++ b/db/migrate/20250321185904_create_event_registrations.rb
@@ -1,0 +1,10 @@
+class CreateEventRegistrations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :event_registrations do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :attendee, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250324230350_create_venues.rb
+++ b/db/migrate/20250324230350_create_venues.rb
@@ -1,0 +1,14 @@
+class CreateVenues < ActiveRecord::Migration[8.0]
+  def change
+    create_table :venues do |t|
+      t.string  :name, null: false
+      t.integer :max_capacity, null: false
+      t.decimal :price_per_seat, precision: 10, scale: 2, null: false
+
+      # each venue will have a location
+      t.references :location, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250324230427_add_venue_reference_to_events.rb
+++ b/db/migrate/20250324230427_add_venue_reference_to_events.rb
@@ -1,0 +1,7 @@
+class AddVenueReferenceToEvents < ActiveRecord::Migration[8.0]
+  def change
+    change_table :events do |t|
+      t.references :venue, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20250324232624_remove_locationfrom_events.rb
+++ b/db/migrate/20250324232624_remove_locationfrom_events.rb
@@ -1,0 +1,5 @@
+class RemoveLocationfromEvents < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :events, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_20_175625) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_21_185904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "event_registrations", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.bigint "attendee_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["attendee_id"], name: "index_event_registrations_on_attendee_id"
+    t.index ["event_id"], name: "index_event_registrations_on_event_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "name", null: false
@@ -23,6 +32,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_20_175625) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "price"
   end
 
   create_table "locations", force: :cascade do |t|
@@ -65,6 +75,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_20_175625) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "event_registrations", "events"
+  add_foreign_key "event_registrations", "users", column: "attendee_id"
   add_foreign_key "events", "users", column: "organizer_id"
   add_foreign_key "locations", "organizations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_21_185904) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_24_232624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "event_registrations", force: :cascade do |t|
     t.bigint "event_id", null: false
     t.bigint "attendee_id", null: false
+    t.string "role"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["attendee_id"], name: "index_event_registrations_on_attendee_id"
@@ -27,12 +28,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_21_185904) do
     t.string "name", null: false
     t.text "description"
     t.string "event_type", null: false
-    t.string "location", null: false
     t.integer "organizer_id", null: false
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.float "price"
+    t.bigint "venue_id", null: false
+    t.index ["venue_id"], name: "index_events_on_venue_id"
   end
 
   create_table "locations", force: :cascade do |t|
@@ -75,8 +76,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_21_185904) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  create_table "venues", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "max_capacity", null: false
+    t.decimal "price_per_seat", precision: 10, scale: 2, null: false
+    t.bigint "location_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_venues_on_location_id"
+  end
+
   add_foreign_key "event_registrations", "events"
   add_foreign_key "event_registrations", "users", column: "attendee_id"
   add_foreign_key "events", "users", column: "organizer_id"
+  add_foreign_key "events", "venues"
   add_foreign_key "locations", "organizations"
+  add_foreign_key "venues", "locations"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,32 +1,45 @@
 # Delete all objects to reset the db
 EventRegistration.delete_all
 Event.delete_all
-AttendeeUser.delete_all
+AdminUser.delete_all
+ExecutiveUser.delete_all
 OrganizerUser.delete_all
+AttendeeUser.delete_all
+Venue.delete_all
 Location.delete_all
 Organization.delete_all
-ExecutiveUser.delete_all
-AdminUser.delete_all
 
 # Repopulate the db
 AdminUser.create!(username: "admin", password: "password", email: "admin@edu-events.ca", first_name: "John", last_name: "Doe")
 ExecutiveUser.create!(username: "executive", password: "password", email: "executive@edu-events.ca", first_name: "Jane", last_name: "Smith")
-
-# I have to nest the location inside the organization cause the location model has a belongs_to association with the organization model
-# however i can change the model validations itself but i did this instead
-Organization.create!(
-  name: "Concordia University",
-  website: "https://www.concordia.ca",
-  phone: "+5141234567",
-  locations_attributes: [
-    { name: "SGW Campus", address1: "1455 De Maisonneuve Blvd. W.", city: "Montreal", state: "QC", country: "CANADA", postal_code: "H3G 1M8" },
-    { name: "Loyola Campus", address1: "7141 Sherbrooke St. W.", city: "Montreal", state: "QC", country: "CANADA", postal_code: "H4B 1R6" }
-  ]
-)
-
 organizer = OrganizerUser.create!(username: "organizer", password: "password", email: "organizer@edu-events.ca", first_name: "George", last_name: "Staples")
 speaker = AttendeeUser.create!(username: "speaker", password: "password", email: "speaker@edu-events.ca", first_name: "Marc", last_name: "Williams", attendee_type: "speaker")
 listener = AttendeeUser.create!(username: "listener", password: "password", email: "listener@edu-events.ca", first_name: "Sarah", last_name: "Hull", attendee_type: "listener")
-event = Event.create!(name: "ConUHacks IX", event_type: "competition", location: "JMSB", organizer_id: organizer.id, price:0.00)
-EventRegistration.create!(event_id: event.id, attendee_id: listener.id, role: "listener")
-EventRegistration.create!(event_id: event.id, attendee_id: speaker.id, role: "speaker")
+
+# I removed the organization validation that checks for the presence of at least one location when creating it because
+# there was too many issues when creating specs for organizations, locations, venues, etc.
+# Instead, we'll just create an organization first, and then we'll associate them with locations, like we are doing here.
+organization = Organization.create!(name: "Concordia University", website: "https://www.concordia.ca", phone: "+5141234567")
+location = Location.create!(name: "SGW Campus", address1: "1455 De Maisonneuve Blvd. W.", address2: "Suite 203", city: "Montreal", state: "QC", country: "CANADA", postal_code: "H3G 1M8", organization_id: organization.id)
+venue = Venue.create!(name: "H - Sir George Williams University Alumni Auditorium (H-110)", max_capacity: 692, price_per_seat: 0.0, location_id: location.id)
+events = [
+  { name: "Tech Innovators Summit", event_type: "conference" },
+  { name: "AI & Machine Learning Workshop", event_type: "workshop" },
+  { name: "Cybersecurity Seminar", event_type: "seminar" },
+  { name: "Hackathon 2025", event_type: "competition" },
+  { name: "Entrepreneurship Bootcamp", event_type: "workshop" },
+  { name: "Future of Web Development", event_type: "conference" },
+  { name: "Startup Pitch Battle", event_type: "competition" },
+  { name: "Leadership & Growth Seminar", event_type: "seminar" },
+  { name: "Cloud Computing Masterclass", event_type: "workshop" },
+  { name: "Game Development Jam", event_type: "competition" },
+  { name: "AI Ethics & Policy Panel", event_type: "seminar" },
+  { name: "Coding Bootcamp Challenge", event_type: "competition" },
+  { name: "Product Management Insights", event_type: "seminar" }
+]
+
+events.each do |event_data|
+  event = Event.create!(name: event_data[:name], event_type: event_data[:event_type], organizer_id: organizer.id, venue_id: venue.id)
+  EventRegistration.create!(event_id: event.id, attendee_id: listener.id, role: "listener") if rand(2) == 1
+  EventRegistration.create!(event_id: event.id, attendee_id: speaker.id, role: "speaker") if rand(2) == 1
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,4 +28,5 @@ organizer = OrganizerUser.create!(username: "organizer", password: "password", e
 speaker = AttendeeUser.create!(username: "speaker", password: "password", email: "speaker@edu-events.ca", first_name: "Marc", last_name: "Williams", attendee_type: "speaker")
 listener = AttendeeUser.create!(username: "listener", password: "password", email: "listener@edu-events.ca", first_name: "Sarah", last_name: "Hull", attendee_type: "listener")
 event = Event.create!(name: "ConUHacks IX", event_type: "competition", location: "JMSB", organizer_id: organizer.id, price:0.00)
-EventRegistration.create!(event_id: event.id, attendee_id: listener.id)
+EventRegistration.create!(event_id: event.id, attendee_id: listener.id, role: "listener")
+EventRegistration.create!(event_id: event.id, attendee_id: speaker.id, role: "speaker")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,6 @@ Organization.delete_all
 # Repopulate the db
 AdminUser.create!(username: "admin", password: "password", email: "admin@edu-events.ca", first_name: "John", last_name: "Doe")
 ExecutiveUser.create!(username: "executive", password: "password", email: "executive@edu-events.ca", first_name: "Jane", last_name: "Smith")
-OrganizerUser.create!(username: "organizer", password: "password", email: "organizer@edu-events.ca", first_name: "George", last_name: "Staples")
-AttendeeUser.create!(username: "speaker", password: "password", email: "speaker@edu-events.ca", first_name: "Marc", last_name: "Williams", attendee_type: "speaker")
-AttendeeUser.create!(username: "listener", password: "password", email: "listener@edu-events.ca", first_name: "Sarah", last_name: "Hull", attendee_type: "listener")
 
 # I have to nest the location inside the organization cause the location model has a belongs_to association with the organization model
 # however i can change the model validations itself but i did this instead
@@ -24,3 +21,9 @@ Organization.create!(
     { name: "Loyola Campus", address1: "7141 Sherbrooke St. W.", city: "Montreal", state: "QC", country: "CANADA", postal_code: "H4B 1R6" }
   ]
 )
+
+organizer = OrganizerUser.create!(username: "organizer", password: "password", email: "organizer@edu-events.ca", first_name: "George", last_name: "Staples")
+speaker = AttendeeUser.create!(username: "speaker", password: "password", email: "speaker@edu-events.ca", first_name: "Marc", last_name: "Williams", attendee_type: "speaker")
+listener = AttendeeUser.create!(username: "listener", password: "password", email: "listener@edu-events.ca", first_name: "Sarah", last_name: "Hull", attendee_type: "listener")
+event = Event.create!(name: "ConUHacks IX", event_type: "competition", location: "JMSB", organizer_id: organizer.id, price:0.00)
+EventRegistration.create!(event_id: event.id, attendee_id: listener.id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,12 @@
 # Delete all objects to reset the db
+EventRegistration.delete_all
 Event.delete_all
-AdminUser.delete_all
-ExecutiveUser.delete_all
-OrganizerUser.delete_all
 AttendeeUser.delete_all
+OrganizerUser.delete_all
 Location.delete_all
 Organization.delete_all
-EventRegistration.delete_all
+ExecutiveUser.delete_all
+AdminUser.delete_all
 
 # Repopulate the db
 AdminUser.create!(username: "admin", password: "password", email: "admin@edu-events.ca", first_name: "John", last_name: "Doe")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,12 @@
 # Delete all objects to reset the db
+Event.delete_all
 AdminUser.delete_all
 ExecutiveUser.delete_all
 OrganizerUser.delete_all
 AttendeeUser.delete_all
 Location.delete_all
 Organization.delete_all
+EventRegistration.delete_all
 
 # Repopulate the db
 AdminUser.create!(username: "admin", password: "password", email: "admin@edu-events.ca", first_name: "John", last_name: "Doe")

--- a/spec/factories/event_registrations.rb
+++ b/spec/factories/event_registrations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :event_registration do
+    event { nil }
+    attendee { nil }
+    registered_as { "MyString" }
+  end
+end

--- a/spec/factories/event_registrations.rb
+++ b/spec/factories/event_registrations.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :event_registration do
-    event { nil }
-    attendee { nil }
-    registered_as { "MyString" }
+    event { create(:competition_event) }
+    attendee { create(:attendee_listener_user) }
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -4,7 +4,11 @@ FactoryBot.define do
     description { "MyText" }
     event_type { "MyString" }
     location { "MyString" }
-    organizer_id { 1 }
+    organizer_id { create(:organizer).id }
     published_at { "2025-03-12 16:52:13" }
+
+    factory :competition_event do
+      event_type { "competition" }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,10 +13,17 @@ FactoryBot.define do
       email { "speaker@edu-events.ca" }
     end
 
-    factory :attendee_listener_user do
+    factory :attendee_listener_user, class: "AttendeeUser" do
       attendee_type { "listener" }
-      username { "listener" }
-      email { "listener@edu-events.ca" }
+      username { Faker::Internet.unique.username }
+      email { Faker::Internet.unique.email }
+      password { "password" }
+      password_confirmation { "password" }
+    end
+
+    factory :organizer do
+      username { "organizer" }
+      email { "organizer@edu-events.ca" }
     end
   end
 end

--- a/spec/mailers/previews/event_registration_mailer_preview.rb
+++ b/spec/mailers/previews/event_registration_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/event_registration_mailer_mailer
+class EventRegistrationMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EventRegistration, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### Description
* This PR implements the ability for attendees to register for events, as either a listener or a speaker (depending on their type).
* Attendees can now view their registration details and cancel their registration. 
* Listener attendees can only register as listeners for events.
* Speaker attendees can register as either listeners, or speakers.
* Attendees cannot register twice for the same event.
* The EventRegistrationMailer was created to send a confirmation email to attendees when they successfully register for an event.
* Added `letter_opener_web` gem so we can see email previews at `localhost:3000/letter_opener`

### `registration_confirmation` mailer example
<img width="460" alt="Screenshot 2025-03-22 at 12 26 50 PM" src="https://github.com/user-attachments/assets/0d7d5657-35ac-4098-ba4c-ea9c9bf8efb9" />

### An example of registration details (show) page for a listener
<img width="493" alt="Screenshot 2025-03-22 at 12 28 18 PM" src="https://github.com/user-attachments/assets/08718331-dba0-4887-a513-f974516fd7e2" />

### An example of an event (show) page for a speaker
<img width="532" alt="Screenshot 2025-03-22 at 12 29 38 PM" src="https://github.com/user-attachments/assets/d8c61975-11e7-4f44-979f-0e31482d7236" />
